### PR TITLE
Remove `offset`* locals which is used only once

### DIFF
--- a/practice1/eurodiffusion/eurodiffusion.go
+++ b/practice1/eurodiffusion/eurodiffusion.go
@@ -16,12 +16,10 @@ func CalculateEuroDiffusionForTestCase(countries common.CountryList) common.Test
 		citiesGrid[y] = make([]*common.City, countCols)
 	}
 	// put cities into grid
-	offsetX := minXl
-	offsetY := minYl
 	for _, country := range countries {
 		country.InitCities()
 		for _, city := range country.Cities {
-			citiesGrid[city.Y-offsetY][city.X-offsetX] = city
+			citiesGrid[city.Y-minYl][city.X-minXl] = city
 		}
 	}
 	// start euro diffusion


### PR DESCRIPTION
There are two variables `offsetX` and `offsetY`, which are used only once in function and also they just copy the value from another variables. 

I've removed these unused local variables.

This PR closes #2