### PR TITLE
Fix typo in `IsCompleated` field in Country struct

### DIFF
--- a/practice1/common/common.go
+++ b/practice1/common/common.go
@@ -16,7 +16,7 @@ type Country struct {
 	Xh                      int
 	Yh                      int
 	Cities                  []*City
-	IsCompleated            bool
+	IsCompleted            bool
 	NumberDaysToBeCompleted int
 }
 

--- a/practice1/eurodiffusion/eurodiffusion.go
+++ b/practice1/eurodiffusion/eurodiffusion.go
@@ -78,11 +78,11 @@ func getResultsForTestCase(countries common.CountryList) common.TestCaseResults 
 func checkIfAllCountriesAreFullAndSetCompletedOnesIfNeeded(countries common.CountryList, currentDay int) bool {
 	allCountriesAreFull := true
 	for _, country := range countries {
-		if !country.IsCompleated && country.IsFull(countries) {
-			country.IsCompleated = true
+		if !country.IsCompleted && country.IsFull(countries) {
+			country.IsCompleted = true
 			country.NumberDaysToBeCompleted = currentDay
 		}
-		if !country.IsCompleated {
+		if !country.IsCompleted {
 			allCountriesAreFull = false
 		}
 	}


### PR DESCRIPTION
There was a typo in the `IsCompleated` field in the `Country` struct.

I've renamed this field so typo is fixed.

This PR closes #4 