### PR TITLE
Simplify `transferAmountOfMoneyBetweenCities` func

### DIFF
--- a/practice1/eurodiffusion/eurodiffusion.go
+++ b/practice1/eurodiffusion/eurodiffusion.go
@@ -109,13 +109,14 @@ func getAmountsToTransferAtTheBegginingOfTheDay(cities [][]*common.City, rows, c
 }
 
 func transferAmountOfMoneyBetweenCities(cityFrom, cityTo *common.City, amounts map[*common.Country]int) {
-	if cityTo != nil {
-		for country := range cityFrom.CoinsAmount {
-			sumToTransfer := amounts[country]
-			if sumToTransfer > 0 {
-				cityFrom.CoinsAmount[country] -= sumToTransfer
-				cityTo.CoinsAmount[country] += sumToTransfer
-			}
+	if cityTo == nil {
+		return
+	}
+	for country := range cityFrom.CoinsAmount {
+		sumToTransfer := amounts[country]
+		if sumToTransfer > 0 {
+			cityFrom.CoinsAmount[country] -= sumToTransfer
+			cityTo.CoinsAmount[country] += sumToTransfer
 		}
 	}
 }


### PR DESCRIPTION
Reduce levels number in `transferAmountOfMoneyBetweenCities` function by checking null condition before entire operations.

Enhanced function by simplifying number of code levels.

This PR closes #5 issue