### PR TITLE
Fix typo and rename `getMinXlMinYlMaxYhMaxMh` func

### DIFF
--- a/practice1/eurodiffusion/eurodiffusion.go
+++ b/practice1/eurodiffusion/eurodiffusion.go
@@ -5,7 +5,7 @@ import (
 )
 
 func CalculateEuroDiffusionForTestCase(countries common.CountryList) common.TestCaseResults {
-	minXl, minYl, maxYh, maxXh := getMinXlMinYlMaxYhMaxMh(countries)
+	minXl, minYl, maxYh, maxXh := getMinXlMinYlMaxYhMaxXhCoordsOfAllCountries(countries)
 	countRows := maxYh - minYl + 1
 	countCols := maxXh - minXl + 1
 	// initialize trimmed grid of cities
@@ -119,7 +119,7 @@ func transferAmountOfMoneyBetweenCities(cityFrom, cityTo *common.City, amounts m
 	}
 }
 
-func getMinXlMinYlMaxYhMaxMh(countries common.CountryList) (int, int, int, int) {
+func getMinXlMinYlMaxYhMaxXhCoordsOfAllCountries(countries common.CountryList) (int, int, int, int) {
 	minXl := common.MaxCoordValue
 	minYl := common.MaxCoordValue
 	maxYh := common.MinCoordValue


### PR DESCRIPTION
There was a typo in `getMinXlMinYlMaxYhMaxMh` function name: `Mh` should be `Xh`. Also this name wasn't clear and obvious. 

I've fixed typo and renamed this function into `getMinXlMinYlMaxYhMaxXhCoordsOfAllCountries` in order to make it more clearer.

This PR closes #14 issue