### PR TITLE
Verify all contries are neighborhoods without overlap

### DIFF
--- a/practice1/common/common.go
+++ b/practice1/common/common.go
@@ -1,5 +1,7 @@
 package common
 
+import "fmt"
+
 const (
 	MaxNumberOfCountries         = 20
 	MaxCountryNameLength         = 25
@@ -76,4 +78,34 @@ func (c *Country) IsFull(countries CountryList) bool {
 		}
 	}
 	return true
+}
+
+func VerifyAllCountriesAreNeighborhoodsAndNonOverlapping(countries CountryList) error {
+	for _, country := range countries {
+		if country.Xl > country.Xh || country.Yl > country.Yh {
+			return fmt.Errorf("country %s has got invalid coords", country.Name)
+		}
+		countryHasGotNeighborhoods := false
+		for _, anotherCountry := range countries {
+			if country == anotherCountry {
+				continue
+			}
+			if country.Xh < anotherCountry.Xl || country.Xl > anotherCountry.Xh ||
+				country.Yh < anotherCountry.Yl || country.Yl > anotherCountry.Yh {
+				if !countryHasGotNeighborhoods {
+					countryHasGotNeighborhoods =
+						((anotherCountry.Xl-country.Xh == 1 || country.Xl-anotherCountry.Xh == 1) &&
+							anotherCountry.Yl <= country.Yh && anotherCountry.Yh >= country.Yl) ||
+							((anotherCountry.Yl-country.Yh == 1 || country.Yl-anotherCountry.Yh == 1) &&
+								anotherCountry.Xl <= country.Xh && anotherCountry.Xh >= country.Xl)
+				}
+			} else {
+				return fmt.Errorf("country %s is overlapping with country %s", country.Name, anotherCountry.Name)
+			}
+		}
+		if !countryHasGotNeighborhoods && len(countries) > 1 {
+			return fmt.Errorf("country %s doesn't have got neighborhoods", country.Name)
+		}
+	}
+	return nil
 }

--- a/practice1/main.go
+++ b/practice1/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/akrava/software-engineering-methodology-practices/practice1/common"
 	"github.com/akrava/software-engineering-methodology-practices/practice1/eurodiffusion"
 	"github.com/akrava/software-engineering-methodology-practices/practice1/parser"
 )
@@ -14,9 +15,17 @@ func main() {
 		log.Printf("Couldn't parse test cases from input: %v", err)
 		os.Exit(1)
 	}
+	testCasesResults := []common.TestCaseResults{}
 	for i, testCase := range testCases {
+		if err := common.VerifyAllCountriesAreNeighborhoodsAndNonOverlapping(testCase); err != nil {
+			log.Printf("Test case #%d is invalid: %v", i, err)
+			os.Exit(1)
+		}
 		results := eurodiffusion.CalculateEuroDiffusionForTestCase(testCase)
-		if err := parser.WriteResultsOfTestCase(os.Stdout, results, i+1); err != nil {
+		testCasesResults = append(testCasesResults, results)
+	}
+	for i, testCaseResult := range testCasesResults {
+		if err := parser.WriteResultsOfTestCase(os.Stdout, testCaseResult, i+1); err != nil {
 			log.Printf("Couldn't write results of test case #%d: %v", i+1, err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
There was a bug with infinite loop when some countries doesn't have got neighbor cities. Also there was a bug with countries overlap.

I've fixed these bugs by introducing new `VerifyAllCountriesAreNeighborhoodsAndNonOverlapping` function. This function verifies that all countries are neighborhoods and they are not overlapping each other.

This PR closes #16 issue